### PR TITLE
Fluent indexing check for both adding and removing documents

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,6 +10,7 @@ SilverStripe\Forager\Service\IndexData:
     ForagerFluentIndexDataExtension: SilverStripe\ForagerFluent\Extensions\IndexDataExtension
 
 SilverStripe\Forager\DataObject\DataObjectDocument:
+  require_data_object: false
   extensions:
     FluentDataObjectDocumentExtension: SilverStripe\ForagerFluent\Extensions\DataObjectDocumentExtension
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -11,6 +11,7 @@ SilverStripe\Forager\Service\IndexData:
 
 SilverStripe\Forager\DataObject\DataObjectDocument:
   require_data_object: false
+  use_synchronous_dependencies: true
   extensions:
     FluentDataObjectDocumentExtension: SilverStripe\ForagerFluent\Extensions\DataObjectDocumentExtension
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -9,13 +9,17 @@ SilverStripe\Forager\Service\IndexData:
   extensions:
     ForagerFluentIndexDataExtension: SilverStripe\ForagerFluent\Extensions\IndexDataExtension
 
+SilverStripe\Forager\DataObject\DataObjectDocument:
+  extensions:
+    FluentDataObjectDocumentExtension: SilverStripe\ForagerFluent\Extensions\DataObjectDocumentExtension
+
 ---
 Name: forager-fluent-context
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Forager\Service\IndexData:
-      properties:
-        contexts:
-          fluent:
-            SilverstripeForagerLiveIndexDataContext: '%$SilverStripe\Forager\Service\LiveIndexDataContext'
-            SilverstripeForagerLocaleIndexDataContext: '%$SilverStripe\ForagerFluent\Service\LocaleIndexDataContext'
+    properties:
+      contexts:
+        fluent:
+          SilverstripeForagerLiveIndexDataContext: '%$SilverStripe\Forager\Service\LiveIndexDataContext'
+          SilverstripeForagerLocaleIndexDataContext: '%$SilverStripe\ForagerFluent\Service\LocaleIndexDataContext'

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/cms": "^6",
-        "silverstripe/silverstripe-forager": "2.0.x-dev",
+        "silverstripe/silverstripe-forager": "^2.0.0",
         "tractorcow/silverstripe-fluent": "^8"
     },
     "require-dev": {

--- a/src/Extensions/DataObjectDocumentExtension.php
+++ b/src/Extensions/DataObjectDocumentExtension.php
@@ -4,7 +4,6 @@ namespace SilverStripe\ForagerFluent\Extensions;
 
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\State\FluentState;
 
@@ -15,43 +14,6 @@ use TractorCow\Fluent\State\FluentState;
  */
 class DataObjectDocumentExtension extends Extension
 {
-
-    /**
-     * Provide a fallback for retrieving Fluent-enabled DataObjects that may not exist in the current locale.
-     *
-     * This is particularly useful when RemoveDataObjectJob is trying to find dependent documents
-     * in archived mode, where the locale context might cause objects to not be found.
-     *
-     * @param DataObject|null $dataObject The DataObject (will be null when this extension is called)
-     * @param string $className The class name of the DataObject
-     * @param int $id The ID of the DataObject
-     * @param bool $isVersioned Whether the DataObject is versioned
-     * @param bool $shouldFallbackToLatestVersion Whether to fallback to latest version
-     */
-    public function updateGetDataObject(
-        ?DataObject &$dataObject,
-        string $className,
-        int $id,
-        bool $isVersioned,
-        bool $shouldFallbackToLatestVersion
-    ): void {
-        // Only handle if DataObject is still null and class has Fluent extension
-        if ($dataObject || !DataObject::has_extension($className, FluentExtension::class)) {
-            return;
-        }
-
-        // Try to get the base record without locale filtering
-        $dataObject = DataObject::get($className)
-            ->setDataQueryParam('Fluent.Locale', null)
-            ->byID($id);
-
-        if ($dataObject || !$isVersioned) {
-            return;
-        }
-
-        // If still not found and versioned, try the latest version without locale filtering
-        $dataObject = Versioned::get_latest_version($className, $id);
-    }
 
     /**
      * Update the isPublished check to be Fluent-aware, considering fallback locales.

--- a/src/Extensions/DataObjectDocumentExtension.php
+++ b/src/Extensions/DataObjectDocumentExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SilverStripe\ForagerFluent\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Extension\FluentExtension;
+
+/**
+ * Extension for DataObjectDocument to handle Fluent-specific DataObject retrieval
+ *
+ * @property \SilverStripe\Forager\DataObject\DataObjectDocument $owner
+ */
+class DataObjectDocumentExtension extends Extension
+{
+
+    /**
+     * Provide a fallback for retrieving Fluent-enabled DataObjects that may not exist in the current locale.
+     *
+     * This is particularly useful when RemoveDataObjectJob is trying to find dependent documents
+     * in archived mode, where the locale context might cause objects to not be found.
+     *
+     * @param DataObject|null $dataObject The DataObject (will be null when this extension is called)
+     * @param string $className The class name of the DataObject
+     * @param int $id The ID of the DataObject
+     * @param bool $isVersioned Whether the DataObject is versioned
+     * @param bool $shouldFallbackToLatestVersion Whether to fallback to latest version
+     */
+    public function updateGetDataObject(
+        ?DataObject &$dataObject,
+        string $className,
+        int $id,
+        bool $isVersioned,
+        bool $shouldFallbackToLatestVersion
+    ): void {
+        // Only handle if DataObject is still null and class has Fluent extension
+        if ($dataObject || !DataObject::has_extension($className, FluentExtension::class)) {
+            return;
+        }
+
+        // Try to get the base record without locale filtering
+        $dataObject = DataObject::get($className)
+            ->setDataQueryParam('Fluent.Locale', null)
+            ->byID($id);
+
+        // If still not found and versioned, try latest version without locale filtering
+        if (!$dataObject && $isVersioned) {
+            $dataObject = Versioned::get_latest_version($className, $id);
+        }
+    }
+
+}
+

--- a/src/Extensions/DataObjectDocumentExtension.php
+++ b/src/Extensions/DataObjectDocumentExtension.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\State\FluentState;
 
 /**
  * Extension for DataObjectDocument to handle Fluent-specific DataObject retrieval
@@ -44,11 +45,67 @@ class DataObjectDocumentExtension extends Extension
             ->setDataQueryParam('Fluent.Locale', null)
             ->byID($id);
 
-        // If still not found and versioned, try latest version without locale filtering
-        if (!$dataObject && $isVersioned) {
-            $dataObject = Versioned::get_latest_version($className, $id);
+        if ($dataObject || !$isVersioned) {
+            return;
         }
+
+        // If still not found and versioned, try the latest version without locale filtering
+        $dataObject = Versioned::get_latest_version($className, $id);
+    }
+
+    /**
+     * Update the isPublished check to be Fluent-aware, considering fallback locales.
+     *
+     * This method is called from DataObjectDocument::shouldIndex() to allow
+     * content published in fallback locales to be indexed in dependent locales.
+     *
+     * @param DataObject $dataObject
+     * @param bool $isPublished
+     */
+    public function updateIsPublishedForSearch(DataObject $dataObject, bool &$isPublished): void
+    {
+        // If the object doesn't have Fluent extension, use default behaviour
+        if (!$dataObject->hasExtension(FluentExtension::class)) {
+            return;
+        }
+
+        $currentLocaleCode = FluentState::singleton()->getLocale();
+
+        if (!$currentLocaleCode) {
+            return;
+        }
+
+        // Get locale information for this DataObject in the current locale
+        $localInformation = $dataObject->LocaleInformation($currentLocaleCode);
+
+        // Check if the object exists in any locale
+        if (!$localInformation->Exists()) {
+            $isPublished = false;
+
+            return;
+        }
+
+        // Check if it's published in the source locale
+        if ($localInformation->IsPublished(true)) {
+            $isPublished = true;
+
+            return;
+        }
+
+        // If not published in this locale, check if the source locale is published
+        $sourceLocale = $localInformation->getSourceLocale();
+
+        if (!$sourceLocale || $sourceLocale->Locale === $currentLocaleCode) {
+            // No source locale or source is current locale (already checked above)
+            $isPublished = false;
+
+            return;
+        }
+
+        // Check if the content is published in the source locale
+        $sourceLocalInformation = $dataObject->LocaleInformation($sourceLocale->Locale);
+
+        $isPublished = $sourceLocalInformation->Exists() && $sourceLocalInformation->IsPublished(true);
     }
 
 }
-

--- a/src/Extensions/DataObjectDocumentExtension.php
+++ b/src/Extensions/DataObjectDocumentExtension.php
@@ -19,7 +19,7 @@ class DataObjectDocumentExtension extends Extension
      * Update the isPublished check to be Fluent-aware, considering fallback locales.
      *
      * This method is called from DataObjectDocument::shouldIndex() to allow
-     * content published in fallback locales to be indexed in dependent locales.
+     * content published in fallback locales to be indexed in locale contexts.
      *
      * @param DataObject $dataObject
      * @param bool $isPublished

--- a/src/Extensions/FluentSearchExtension.php
+++ b/src/Extensions/FluentSearchExtension.php
@@ -8,7 +8,6 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\Forager\Interfaces\DataObjectDocumentInterface;
 use SilverStripe\Forager\Service\IndexConfiguration;
-use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -41,60 +40,6 @@ class FluentSearchExtension extends Extension
 
         // note this may be an empty array if no updates are required
         $indexSuffixes = $suffixesForLocalisation;
-    }
-
-    /**
-     * Update the isPublished field for localised documents as in some cases the fallback is all we care about
-     *
-     * @param DataObject $dataObject
-     * @param bool $isPublished
-     * @return void
-     */
-    public function updateIsPublishedForSearch(DataObject $dataObject, bool &$isPublished): void
-    {
-        // If the object doesn't have Fluent extension, use default behaviour
-        if (!$dataObject->hasExtension(FluentExtension::class)) {
-            return;
-        }
-
-        // Get the current locale
-        $currentLocaleCode = FluentState::singleton()->getLocale();
-
-        if (!$currentLocaleCode) {
-            return;
-        }
-
-        // Get locale information for this DataObject in the current locale
-        $localInformation = $dataObject->LocaleInformation($currentLocaleCode);
-
-        // Check if the object exists in any locale
-        if (!$localInformation->Exists()) {
-            $isPublished = false;
-
-            return;
-        }
-
-        // Check if it's published in the source locale
-        if ($localInformation->IsPublished(true)) {
-            $isPublished = true;
-
-            return;
-        }
-
-        // If not published in this locale, check if the source locale is published
-        $sourceLocale = $localInformation->getSourceLocale();
-
-        if (!$sourceLocale || $sourceLocale->Locale === $currentLocaleCode) {
-            // No source locale or source is current locale
-            $isPublished = false;
-
-            return;
-        }
-
-        // Check if the content is published in the source locale
-        $sourceLocalInformation = $dataObject->LocaleInformation($sourceLocale->Locale);
-
-        $isPublished = $sourceLocalInformation->Exists() && $sourceLocalInformation->IsPublished(true);
     }
 
     /**

--- a/src/Extensions/FluentSearchExtension.php
+++ b/src/Extensions/FluentSearchExtension.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\Forager\Interfaces\DataObjectDocumentInterface;
 use SilverStripe\Forager\Service\IndexConfiguration;
+use SilverStripe\ORM\DataObject;
 use TractorCow\Fluent\Extension\FluentExtension;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -40,6 +41,60 @@ class FluentSearchExtension extends Extension
 
         // note this may be an empty array if no updates are required
         $indexSuffixes = $suffixesForLocalisation;
+    }
+
+    /**
+     * Update the isPublished field for localised documents as in some cases the fallback is all we care about
+     *
+     * @param DataObject $dataObject
+     * @param bool $isPublished
+     * @return void
+     */
+    public function updateIsPublishedForSearch(DataObject $dataObject, bool &$isPublished): void
+    {
+        // If the object doesn't have Fluent extension, use default behaviour
+        if (!$dataObject->hasExtension(FluentExtension::class)) {
+            return;
+        }
+
+        // Get the current locale
+        $currentLocaleCode = FluentState::singleton()->getLocale();
+
+        if (!$currentLocaleCode) {
+            return;
+        }
+
+        // Get locale information for this DataObject in the current locale
+        $localInformation = $dataObject->LocaleInformation($currentLocaleCode);
+
+        // Check if the object exists in any locale
+        if (!$localInformation->Exists()) {
+            $isPublished = false;
+
+            return;
+        }
+
+        // Check if it's published in the source locale
+        if ($localInformation->IsPublished(true)) {
+            $isPublished = true;
+
+            return;
+        }
+
+        // If not published in this locale, check if the source locale is published
+        $sourceLocale = $localInformation->getSourceLocale();
+
+        if (!$sourceLocale || $sourceLocale->Locale === $currentLocaleCode) {
+            // No source locale or source is current locale
+            $isPublished = false;
+
+            return;
+        }
+
+        // Check if the content is published in the source locale
+        $sourceLocalInformation = $dataObject->LocaleInformation($sourceLocale->Locale);
+
+        $isPublished = $sourceLocalInformation->Exists() && $sourceLocalInformation->IsPublished(true);
     }
 
     /**


### PR DESCRIPTION
Add DataObjectDocument extension for checking fluent objects are published in a fallback locale.

Update the getDataObject to handle deleted pages